### PR TITLE
Backend renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
 - Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
 - `MetricsReaderBuilder::patience` now returns `Self`
+- For backends, rename `Serve` &rarr; `vcl::VclBackend`, `Transfer` &rarr; `vcl::VclResponse`
 
 # 0.3.0 (2024-12-12)
 

--- a/examples/vmod_be/README.md
+++ b/examples/vmod_be/README.md
@@ -23,7 +23,7 @@ import be from "path/to/libbe.so";
 
 parrot is our VCL object, which just holds a rust Backend,
 it only needs two functions:
-- new(), so that the VCL can instantiate it
-- backend(), so that we can produce a C pointer for varnish to use
+- `new()`, so that the VCL can instantiate it
+- `backend()`, so that we can produce a C pointer for varnish to use
 
 #### Method `BACKEND <object>.backend()`

--- a/examples/vmod_be/src/lib.rs
+++ b/examples/vmod_be/src/lib.rs
@@ -1,10 +1,10 @@
-use varnish::vcl::{Backend, Ctx, Serve, Transfer, VclError};
+use varnish::vcl::{Backend, Ctx, VclBackend, VclError, VclResponse};
 
 varnish::run_vtc_tests!("tests/*.vtc");
 
 #[allow(non_camel_case_types)]
 struct parrot {
-    backend: Backend<Sentence, Body>,
+    backend: Backend<ParrotBackend, ResponseBody>,
 }
 
 /// a simple STRING dictionary in your VCL
@@ -13,12 +13,12 @@ mod be {
     use varnish::ffi::VCL_BACKEND;
     use varnish::vcl::{Backend, Ctx, VclError};
 
-    use super::{parrot, Sentence};
+    use super::{parrot, ParrotBackend};
 
     /// parrot is our VCL object, which just holds a rust Backend,
     /// it only needs two functions:
-    /// - new(), so that the VCL can instantiate it
-    /// - backend(), so that we can produce a C pointer for varnish to use
+    /// - `new()`, so that the VCL can instantiate it
+    /// - `backend()`, so that we can produce a C pointer for varnish to use
     impl parrot {
         pub fn new(
             ctx: &mut Ctx,
@@ -30,12 +30,12 @@ mod be {
             // to create the backend, we need:
             // - the vcl context, that we just pass along
             // - the vcl_name (how the vcl writer named the object)
-            // - a struct that implements the Serve trait
+            // - a struct that implements the VclBackend trait
             let backend = Backend::new(
                 ctx,
                 "parrot",
                 name,
-                Sentence {
+                ParrotBackend {
                     data: Vec::from(to_repeat),
                 },
                 false,
@@ -50,47 +50,45 @@ mod be {
     }
 }
 
-// Sentence is just a Vec<u8> holding the string we were asked to repeat
-struct Sentence {
+/// [`ParrotBackend`] is just a `Vec<u8>` holding the string we were asked to repeat
+struct ParrotBackend {
     data: Vec<u8>,
 }
 
-// a lot of the Serve trait's methods are optional, but we need to implement
-// - get_type() for debugging reasons when something fails
-// - get_headers() that actually builds the response headers,
-//   and returns a Body
-impl Serve<Body> for Sentence {
-    fn get_headers(&self, ctx: &mut Ctx) -> Result<Option<Body>, VclError> {
+/// A lot of the [`VclBackend`] trait's methods are optional, but we need to implement
+/// - [`Self::get_response`] that actually builds the response headers, and returns a Body
+impl VclBackend<ResponseBody> for ParrotBackend {
+    fn get_response(&self, ctx: &mut Ctx) -> Result<Option<ResponseBody>, VclError> {
         let beresp = ctx.http_beresp.as_mut().unwrap();
         beresp.set_status(200);
         beresp.set_header("server", "parrot")?;
 
-        Ok(Some(Body {
-            p: self.data.as_ptr(),
-            left: self.data.len(),
+        Ok(Some(ResponseBody {
+            cursor: self.data.as_ptr(),
+            len: self.data.len(),
         }))
     }
 }
 
-// it's not great to be passing pointers around, but that save us from copying
-// the vector or from using a mutex/arc, and we know the Vec will survive the
-// transfer
-struct Body {
-    p: *const u8,
-    left: usize,
+/// it's not great to be passing pointers around, but that save us from copying
+/// the vector or from using a mutex/arc, and we know the Vec will survive the
+/// transfer
+struct ResponseBody {
+    cursor: *const u8,
+    len: usize,
 }
 
-impl Transfer for Body {
+impl VclResponse for ResponseBody {
     // Varnish will call us over and over, asking us to fill buffers
     // we'll happily oblige by filling as much as we can every time
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, VclError> {
         // can't send more than what we have, or more than what the buffer can hold
-        let l = std::cmp::min(self.left, buf.len());
+        let l = std::cmp::min(self.len, buf.len());
 
         // there's no way for the compiler to prove that self.p isn't dangling
         // at this stage, so we'll ask it to trust us as we rebuild the slice
         // it points to
-        let to_send = unsafe { std::slice::from_raw_parts(self.p, l) };
+        let to_send = unsafe { std::slice::from_raw_parts(self.cursor, l) };
 
         // copy data into the buffer
         for (p, val) in std::iter::zip(buf, to_send) {
@@ -101,9 +99,9 @@ impl Transfer for Body {
         // and once again, we must ask the compiler to trust us as pointer
         // arithmetic is dangerous
         unsafe {
-            self.p = self.p.add(l);
+            self.cursor = self.cursor.add(l);
         }
-        self.left -= l;
+        self.len -= l;
 
         // everything went fine, we copied l bytes into buf
         Ok(l)
@@ -111,6 +109,6 @@ impl Transfer for Body {
 
     // we know from the start how much we'll send
     fn len(&self) -> Option<usize> {
-        Some(self.left)
+        Some(self.len)
     }
 }

--- a/varnish-sys/src/utils.rs
+++ b/varnish-sys/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::ffi::director;
-use crate::vcl::{Serve, Transfer};
+use crate::vcl::{VclBackend, VclResponse};
 
-/// Return the private pointer as a reference to the [`Serve`] object
+/// Return the private pointer as a reference to the [`VclBackend`] object
 /// FIXME: should it return a `&mut` instead?
-pub fn get_backend<S: Serve<T>, T: Transfer>(v: &director) -> &S {
+pub fn get_backend<S: VclBackend<T>, T: VclResponse>(v: &director) -> &S {
     unsafe { v.priv_.cast::<S>().as_ref().unwrap() }
 }


### PR DESCRIPTION
rename `Serve` &rarr; `vcl::VclBackend`, `Transfer` &rarr; `vcl::VclResponse`

This is just the first part of making it more readable. Any other naming suggestions?