### PR TITLE
`vsc` module cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
 - Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
-- `MetricsReaderBuilder::patience` now returns `Self` 
+- `MetricsReaderBuilder::patience` now returns `Self`
 
 # 0.3.0 (2024-12-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   - The buffer does not allow any access to "dirty" (unset) portion of the buffer
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
-- Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat` 
+- Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
+- `MetricsReaderBuilder::patience` now returns `Self` 
 
 # 0.3.0 (2024-12-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - The returned buffers support `Write` trait, and can be inspected/modified what has been written so far
   - The buffer does not allow any access to "dirty" (unset) portion of the buffer
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
+- Remove `vsc` feature - all of its functionality is now available without any feature flags
+- Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat` 
 
 # 0.3.0 (2024-12-12)
 

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ build:
 
 # build all
 build-all-features:
-    cargo build --all-targets --workspace $({{just_executable()}} get-package-exclude-args) --features "ffi,vsc"
+    cargo build --all-targets --workspace $({{just_executable()}} get-package-exclude-args) --features "ffi,metrics-reader"
 
 # Run all tests
 test *ARGS: build

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ build:
 
 # build all
 build-all-features:
-    cargo build --all-targets --workspace $({{just_executable()}} get-package-exclude-args) --features "ffi,metrics-reader"
+    cargo build --all-targets --workspace $({{just_executable()}} get-package-exclude-args) --features "ffi"
 
 # Run all tests
 test *ARGS: build

--- a/varnish/Cargo.toml
+++ b/varnish/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 [features]
 default = []
 ffi = []
-vsc = []
+metrics-reader = []
 
 [dependencies]
 glob.workspace = true

--- a/varnish/Cargo.toml
+++ b/varnish/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 [features]
 default = []
 ffi = []
-metrics-reader = []
 
 [dependencies]
 glob.workspace = true

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -100,10 +100,8 @@ pub use varnish_sys::ffi;
 
 pub mod varnishtest;
 
-#[cfg(feature = "metrics-reader")]
 mod metrics_reader;
-#[cfg(feature = "metrics-reader")]
-pub use metrics_reader::{Format, Metric, MetricsReader, MetricsReaderBuilder, Semantics};
+pub use metrics_reader::{Metric, MetricFormat, MetricsReader, MetricsReaderBuilder, Semantics};
 
 pub use varnish_macros::vmod;
 

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -100,8 +100,10 @@ pub use varnish_sys::ffi;
 
 pub mod varnishtest;
 
-#[cfg(feature = "vsc")]
-pub mod vsc;
+#[cfg(feature = "metrics-reader")]
+mod metrics_reader;
+#[cfg(feature = "metrics-reader")]
+pub use metrics_reader::{Format, Metric, MetricsReader, MetricsReaderBuilder, Semantics};
 
 pub use varnish_macros::vmod;
 

--- a/varnish/src/metrics_reader.rs
+++ b/varnish/src/metrics_reader.rs
@@ -74,17 +74,15 @@ impl<'a> MetricsReaderBuilder<'a> {
     /// it specifies the timeout to use.
     #[must_use]
     pub fn patience(self, t: Option<Duration>) -> Self {
-        let mut arg = match t {
+        let arg = CString::new(match t {
             None => "off".to_string(),
             Some(t) => t.as_secs_f64().to_string(),
-        }
-        .into_bytes();
-        arg.push(0);
+        })
+        .unwrap(); // Can never fail since we control the content of the string
 
         // # Safety
         // we just created this string, no point to double-check it for nul bytes
         unsafe {
-            let arg = CString::from_vec_with_nul_unchecked(arg);
             // TODO: document why this can fail, and if we should return an error
             // TODO: Document why using `self.vsm` here, and `self.vsc` in the other `VSM_Arg` calls
             let ret = ffi::VSM_Arg(self.vsm, 't' as c_char, arg.as_ptr());


### PR DESCRIPTION
A bunch of VSC-related renames per our chat. This way we won't conflict between metrics reader and metrics provider

* Fixed FFI memory bug - `patience` was passing "off" without the null termination to C
* Modified `patience`, refactoring it and making it return `Self` rather than `Result<Self>` 
* deleted `vsc` feature
* `mod vsc` -> inlined at the top crate level
* `Stats` -> `MetricsReader`
* `StatsImpl` -> `MetricsReaderImpl` (private)
* `StatsBuilder` -> `MetricsReaderBuilder`
* `Stat` -> `Metric`
* `Format` -> `MetricsFormat`
* Removed `Format::Unknown` value. This is a very `C-like` pattern that's almost non-existent in Rust. Converted `From` to `TryFrom` -- as it now can return an error  - using `()` for now.

## TODO:
* [ ] Should `Semantics` be renamed into something?
* [ ] `patience` has an internal assert - is this needed? Should it return a real result instead?
* [ ] `patience` uses `self.vsm`, but the `vsc_arg` below uses `self.vsc`?
* [ ] The builder uses `Result<Self, Err>` return pattern - I'm not sure how easy it will be to use... we might want to think if we want `Result<&mut Self, Err>` instead? I'm not certain on this yet
