### PR TITLE
headers can be non-utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - The returned buffers support `Write` trait, and can be inspected/modified what has been written so far
   - The buffer does not allow any access to "dirty" (unset) portion of the buffer
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
+- Header values are now `&[u8]` instead of `&str`
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
 - Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
 - `MetricsReaderBuilder::patience` now returns `Self`

--- a/varnish-sys/src/txt.rs
+++ b/varnish-sys/src/txt.rs
@@ -51,7 +51,10 @@ impl txt {
         // We expect varnishd to always given us a string with a ':' in it
         // If it's not the case, blow up as it might be a sign of a bigger problem.
         let slice = self.to_slice()?;
-        let index = slice.iter().position(|c| *c == b':').expect("headers should always have a :");
+        let index = slice
+            .iter()
+            .position(|c| *c == b':')
+            .expect("headers should always have a :");
         let (key_slice, value_slice) = slice.split_at(index);
 
         let key = from_utf8(key_slice).expect("header names must be UTF-8");

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -126,19 +126,26 @@ impl HttpHeaders<'_> {
             if idx >= self.raw.nhd {
                 None
             } else {
-                self.raw.hd.offset(idx as isize).as_ref().unwrap().to_slice()
+                self.raw
+                    .hd
+                    .offset(idx as isize)
+                    .as_ref()
+                    .unwrap()
+                    .to_slice()
             }
         }
     }
 
     /// Method of an HTTP request, `None` for a response
     pub fn method(&self) -> Option<&str> {
-        self.field(HDR_METHOD).map(|buf| std::str::from_utf8(buf).expect("method must be ascii"))
+        self.field(HDR_METHOD)
+            .map(|buf| std::str::from_utf8(buf).expect("method must be ascii"))
     }
 
     /// URL of an HTTP request, `None` for a response
     pub fn url(&self) -> Option<&str> {
-        self.field(HDR_URL).map(|buf| std::str::from_utf8(buf).expect("method must be UTF-8"))
+        self.field(HDR_URL)
+            .map(|buf| std::str::from_utf8(buf).expect("method must be UTF-8"))
     }
 
     /// Protocol of an object
@@ -146,7 +153,8 @@ impl HttpHeaders<'_> {
     /// It should exist for both requests and responses, but the `Option` is maintained for
     /// consistency.
     pub fn proto(&self) -> Option<&str> {
-        self.field(HDR_PROTO).map(|buf| std::str::from_utf8(buf).expect("protocol must be ascii"))
+        self.field(HDR_PROTO)
+            .map(|buf| std::str::from_utf8(buf).expect("protocol must be ascii"))
     }
 
     /// Set prototype
@@ -163,7 +171,8 @@ impl HttpHeaders<'_> {
 
     /// Response status, `None` for a request
     pub fn status(&self) -> Option<&str> {
-        self.field(HDR_STATUS).map(|buf| std::str::from_utf8(buf).expect("status must be ascii"))
+        self.field(HDR_STATUS)
+            .map(|buf| std::str::from_utf8(buf).expect("status must be ascii"))
     }
 
     /// Set the response status, it will also set the reason
@@ -180,7 +189,8 @@ impl HttpHeaders<'_> {
 
     /// Response reason, `None` for a request
     pub fn reason(&self) -> Option<&str> {
-        self.field(HDR_REASON).map(|buf| std::str::from_utf8(buf).expect("reason must be ascii"))
+        self.field(HDR_REASON)
+            .map(|buf| std::str::from_utf8(buf).expect("reason must be ascii"))
     }
 
     /// Set reason

--- a/varnish/tests/vmod_test/README.md
+++ b/varnish/tests/vmod_test/README.md
@@ -54,3 +54,5 @@ import rustest from "path/to/librustest.so";
 ### Function `STRING rustest.cowprobe_prop([PROBE probe])`
 
 ### Function `STRING rustest.probe_prop([PROBE probe])`
+
+### Function `STRING rustest.merge_all_names()`

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -140,6 +140,14 @@ mod rustest {
         }
     }
 
+    pub fn merge_all_names(ctx: &Ctx) -> String {
+        let mut s = String::new();
+        for (k, _) in ctx.http_req.as_ref().expect("merge_all_names is only available in a client context") {
+            s += k;
+        }
+        s
+    }
+
     #[event]
     pub fn event(event: Event, vfp: &mut FetchFilters) {
         if let Event::Load = event {

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -142,7 +142,11 @@ mod rustest {
 
     pub fn merge_all_names(ctx: &Ctx) -> String {
         let mut s = String::new();
-        for (k, _) in ctx.http_req.as_ref().expect("merge_all_names is only available in a client context") {
+        for (k, _) in ctx
+            .http_req
+            .as_ref()
+            .expect("merge_all_names is only available in a client context")
+        {
             s += k;
         }
         s

--- a/varnish/tests/vmod_test/tests/test01.vtc
+++ b/varnish/tests/vmod_test/tests/test01.vtc
@@ -5,6 +5,7 @@ server s1 {
 	expect req.http.foo == "bar_replaced"
 	expect req.http.baz == "qux"
 	expect req.http.quxx == <undef>
+	expect req.http.all == "quxxHostUser-AgentX-Forwarded-ForVia"
 	txresp
 } -start
 
@@ -12,6 +13,7 @@ varnish v1 -vcl+backend {
 	import rustest from "${vmod}";
 
 	sub vcl_recv {
+		set req.http.all = rustest.merge_all_names();
 		rustest.set_hdr("foo", "bar_replaced");
 		rustest.set_hdr("baz", "qux");
 		rustest.unset_hdr("quxx");
@@ -22,4 +24,14 @@ client c1 {
 	txreq -hdr "quxx: quz"
 	rxresp
 	expect resp.status == 200
+
+
+	# make sure rustest.merge_all_names() doesn't panic on non-utf-8
+	send "GET / HTTP/1.1\r\n"
+        send "foo: "
+        sendhex "A7"
+        send "\r\n"
+        send "\r\n"
+
+        rxresp
 } -run


### PR DESCRIPTION
defensively downgrade header values to &[u8]. We will need a cleaner interface at some point, but this will at least prevent silly panics

this will notably help save https://github.com/gquintard/vmod-reqwest/issues/16