### PR TITLE
Handle raw byte headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - The returned buffers support `Write` trait, and can be inspected/modified what has been written so far
   - The buffer does not allow any access to "dirty" (unset) portion of the buffer
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
+- If header is not a valid UTF-8 str, `txt::to_str` and `txt::parse_header` will return `None`. Use `txt::to_slice` to handle raw bytes. No more panics here.
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
 - Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
 - `MetricsReaderBuilder::patience` now returns `Self`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - The returned buffers support `Write` trait, and can be inspected/modified what has been written so far
   - The buffer does not allow any access to "dirty" (unset) portion of the buffer
   - The buffer must be finalized with `finish()`, which returns `VCL_STRING`, `VCL_BLOB`, or `&[T]` depending on the builder used
-- If header is not a valid UTF-8 str, `txt::to_str` and `txt::parse_header` will return `None`. Use `txt::to_slice` to handle raw bytes. No more panics here.
+- Add support for the non-UTF8 header values by using a `StrOrBytes` enum. This also fixes crashes when non-UTF8 headers are present.
 - Remove `vsc` feature - all of its functionality is now available without any feature flags
 - Rename `Stat` &rarr; `Metrics`, `Stats` &rarr; `MetricsReader`, `StatsBuilder` &rarr; `MetricsReaderBuilder`, and `Format` &rarr; `MetricsFormat`
 - `MetricsReaderBuilder::patience` now returns `Self`

--- a/varnish-sys/src/txt.rs
+++ b/varnish-sys/src/txt.rs
@@ -45,18 +45,19 @@ impl txt {
         }
     }
 
-    /// Convert the `txt` struct to a `&str`.  Will panic if the string is not valid UTF-8.
+    /// Convert the `txt` struct to a `&str`.
+    /// Returns None if the string is not valid UTF-8.
+    /// Use [Self::to_slice] to handle raw bytes.
     #[expect(clippy::wrong_self_convention)] // TODO: drop Copy trait for txt?
     pub fn to_str<'a>(&self) -> Option<&'a str> {
-        self.to_slice().map(|s| from_utf8(s).unwrap())
+        self.to_slice().and_then(|s| from_utf8(s).ok())
     }
 
     /// Parse the `txt` struct as a header, returning a tuple with the key and value,
-    /// trimming the value of leading whitespace.
+    /// trimming the value of leading whitespace. Returns None in case of any issues.
+    /// Use [Self::to_slice] to handle raw bytes, e.g. if the header is not UTF-8.
     pub fn parse_header<'a>(&self) -> Option<(&'a str, &'a str)> {
-        // We expect varnishd to always given us a string with a ':' in it
-        // If it's not the case, blow up as it might be a sign of a bigger problem.
-        let (key, value) = self.to_str()?.split_once(':').unwrap();
+        let (key, value) = self.to_str()?.split_once(':')?;
         // FIXME: Consider `.trim_ascii_start()` if unicode is not a concern
         Some((key, value.trim_start()))
     }

--- a/varnish-sys/src/txt.rs
+++ b/varnish-sys/src/txt.rs
@@ -30,7 +30,7 @@ impl txt {
     /// Convert the `txt` struct to a `&[u8]`.
     /// We want to explicitly differentiate between empty (`None`) and null (`Some([])`) strings.
     #[expect(clippy::wrong_self_convention)] // TODO: drop Copy trait for txt?
-    pub fn to_slice<'a>(&self) -> Option<&'a [u8]> {
+    pub fn to_slice(&self) -> Option<&[u8]> {
         if self.b.is_null() {
             None
         } else {
@@ -48,13 +48,13 @@ impl txt {
 
     /// Convert the `txt` struct to a `StrOrBytes` enum.
     #[expect(clippy::wrong_self_convention)] // TODO: drop Copy trait for txt?
-    pub fn to_str<'a>(&self) -> Option<StrOrBytes<'_>> {
+    pub fn to_str(&self) -> Option<StrOrBytes<'_>> {
         self.to_slice().map(StrOrBytes::from)
     }
 
     /// Parse the `txt` struct as a header, returning a tuple with the key and value,
     /// trimming the value of leading whitespace.
-    pub fn parse_header<'a>(&self) -> Option<(&'a str, StrOrBytes<'_>)> {
+    pub fn parse_header(&self) -> Option<(&str, StrOrBytes<'_>)> {
         // We expect varnishd to always given us a string with a ':' in it
         // If it's not the case, blow up as it might be a sign of a bigger problem.
         let slice = self.to_slice()?;

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -25,7 +25,7 @@ use crate::vcl::{HttpHeaders, LogTag, TestWS, VclError, Workspace};
 /// fn foo(ctx: &Ctx) {
 ///     if let Some(ref req) = ctx.http_req {
 ///         for (name, value) in req {
-///             println!("header {name} has value {value}");
+///             println!("header {name} has value {value:?}");
 ///         }
 ///     }
 /// }

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -16,6 +16,7 @@ use std::slice::from_raw_parts_mut;
 
 use crate::ffi;
 use crate::ffi::VslTag;
+use crate::vcl::str_or_bytes::StrOrBytes;
 use crate::vcl::{VclResult, Workspace};
 
 // C constants pop up as u32, but header indexing uses u16, redefine
@@ -42,14 +43,14 @@ impl HttpHeaders<'_> {
         })
     }
 
-    fn change_header(&mut self, idx: u16, value: &str) -> VclResult<()> {
+    fn change_header<'a>(&mut self, idx: u16, value: impl Into<StrOrBytes<'a>>) -> VclResult<()> {
         assert!(idx < self.raw.nhd);
 
         /* XXX: aliasing warning, it's the same pointer as the one in Ctx */
         let mut ws = Workspace::from_ptr(self.raw.ws);
         unsafe {
             let hd = self.raw.hd.offset(idx as isize).as_mut().unwrap();
-            *hd = ws.copy_bytes_with_null(value)?;
+            *hd = ws.copy_bytes_with_null(value.into())?;
             let hdf = self.raw.hdf.offset(idx as isize).as_mut().unwrap();
             *hdf = 0;
         }
@@ -121,23 +122,29 @@ impl HttpHeaders<'_> {
     }
 
     /// Return header at a specific position
-    fn field(&self, idx: u16) -> Option<&str> {
+    fn field(&self, idx: u16) -> Option<StrOrBytes<'_>> {
         unsafe {
             if idx >= self.raw.nhd {
                 None
             } else {
-                self.raw.hd.offset(idx as isize).as_ref().unwrap().to_str()
+                self.raw
+                    .hd
+                    .offset(idx as isize)
+                    .as_ref()
+                    .unwrap()
+                    .to_slice()
+                    .map(StrOrBytes::from)
             }
         }
     }
 
     /// Method of an HTTP request, `None` for a response
-    pub fn method(&self) -> Option<&str> {
+    pub fn method(&self) -> Option<StrOrBytes<'_>> {
         self.field(HDR_METHOD)
     }
 
     /// URL of an HTTP request, `None` for a response
-    pub fn url(&self) -> Option<&str> {
+    pub fn url(&self) -> Option<StrOrBytes<'_>> {
         self.field(HDR_URL)
     }
 
@@ -145,7 +152,7 @@ impl HttpHeaders<'_> {
     ///
     /// It should exist for both requests and responses, but the `Option` is maintained for
     /// consistency.
-    pub fn proto(&self) -> Option<&str> {
+    pub fn proto(&self) -> Option<StrOrBytes<'_>> {
         self.field(HDR_PROTO)
     }
 
@@ -162,7 +169,7 @@ impl HttpHeaders<'_> {
     }
 
     /// Response status, `None` for a request
-    pub fn status(&self) -> Option<&str> {
+    pub fn status(&self) -> Option<StrOrBytes<'_>> {
         self.field(HDR_STATUS)
     }
 
@@ -179,7 +186,7 @@ impl HttpHeaders<'_> {
     }
 
     /// Response reason, `None` for a request
-    pub fn reason(&self) -> Option<&str> {
+    pub fn reason(&self) -> Option<StrOrBytes<'_>> {
         self.field(HDR_REASON)
     }
 
@@ -191,7 +198,7 @@ impl HttpHeaders<'_> {
     /// Returns the value of a header based on its name
     ///
     /// The header names are compared in a case-insensitive manner
-    pub fn header(&self, name: &str) -> Option<&str> {
+    pub fn header(&self, name: &str) -> Option<StrOrBytes<'_>> {
         self.iter()
             .find(|hdr| name.eq_ignore_ascii_case(hdr.0))
             .map(|hdr| hdr.1)
@@ -206,7 +213,7 @@ impl HttpHeaders<'_> {
 }
 
 impl<'a> IntoIterator for &'a HttpHeaders<'a> {
-    type Item = (&'a str, &'a str);
+    type Item = (&'a str, StrOrBytes<'a>);
     type IntoIter = HttpHeadersIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -221,7 +228,7 @@ pub struct HttpHeadersIter<'a> {
 }
 
 impl<'a> Iterator for HttpHeadersIter<'a> {
-    type Item = (&'a str, &'a str);
+    type Item = (&'a str, StrOrBytes<'a>);
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -67,6 +67,7 @@ impl HttpHeaders<'_> {
 
         let idx = self.raw.nhd;
         self.raw.nhd += 1;
+        // FIXME: optimize this to avoid allocating a temporary string
         let res = self.change_header(idx, &format!("{name}: {value}"));
         if res.is_ok() {
             unsafe {

--- a/varnish-sys/src/vcl/mod.rs
+++ b/varnish-sys/src/vcl/mod.rs
@@ -7,6 +7,7 @@ mod http;
 mod probe;
 #[cfg(not(varnishsys_6))]
 mod processor;
+mod str_or_bytes;
 mod vsb;
 mod ws;
 mod ws_str_buffer;
@@ -20,6 +21,7 @@ pub use http::*;
 pub use probe::*;
 #[cfg(not(varnishsys_6))]
 pub use processor::*;
+pub use str_or_bytes::*;
 pub use vsb::*;
 pub use ws::*;
 pub use ws_str_buffer::WsStrBuffer;

--- a/varnish-sys/src/vcl/str_or_bytes.rs
+++ b/varnish-sys/src/vcl/str_or_bytes.rs
@@ -20,13 +20,11 @@ impl<'a> From<&'a String> for StrOrBytes<'a> {
 
 impl<'a> From<&'a [u8]> for StrOrBytes<'a> {
     fn from(value: &'a [u8]) -> Self {
-        from_utf8(value)
-            .map(StrOrBytes::Utf8)
-            .unwrap_or_else(|_| StrOrBytes::Bytes(value))
+        from_utf8(value).map_or_else(|_| StrOrBytes::Bytes(value), StrOrBytes::Utf8)
     }
 }
 
-impl<'a> AsRef<[u8]> for StrOrBytes<'a> {
+impl AsRef<[u8]> for StrOrBytes<'_> {
     fn as_ref(&self) -> &[u8] {
         match self {
             StrOrBytes::Utf8(s) => s.as_bytes(),

--- a/varnish-sys/src/vcl/str_or_bytes.rs
+++ b/varnish-sys/src/vcl/str_or_bytes.rs
@@ -1,0 +1,36 @@
+use std::str::from_utf8;
+
+#[derive(Debug)]
+pub enum StrOrBytes<'a> {
+    Utf8(&'a str),
+    Bytes(&'a [u8]),
+}
+
+impl<'a> From<&'a str> for StrOrBytes<'a> {
+    fn from(value: &'a str) -> Self {
+        StrOrBytes::Utf8(value)
+    }
+}
+
+impl<'a> From<&'a String> for StrOrBytes<'a> {
+    fn from(value: &'a String) -> Self {
+        StrOrBytes::Utf8(value.as_str())
+    }
+}
+
+impl<'a> From<&'a [u8]> for StrOrBytes<'a> {
+    fn from(value: &'a [u8]) -> Self {
+        from_utf8(value)
+            .map(StrOrBytes::Utf8)
+            .unwrap_or_else(|_| StrOrBytes::Bytes(value))
+    }
+}
+
+impl<'a> AsRef<[u8]> for StrOrBytes<'a> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            StrOrBytes::Utf8(s) => s.as_bytes(),
+            StrOrBytes::Bytes(b) => b,
+        }
+    }
+}

--- a/varnish/tests/vmod_test/README.md
+++ b/varnish/tests/vmod_test/README.md
@@ -54,3 +54,5 @@ import rustest from "path/to/librustest.so";
 ### Function `STRING rustest.cowprobe_prop([PROBE probe])`
 
 ### Function `STRING rustest.probe_prop([PROBE probe])`
+
+### Function `STRING rustest.merge_all_names()`

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -140,6 +140,18 @@ mod rustest {
         }
     }
 
+    pub fn merge_all_names(ctx: &Ctx) -> String {
+        let mut s = String::new();
+        for (k, _) in ctx
+            .http_req
+            .as_ref()
+            .expect("merge_all_names is only available in a client context")
+        {
+            s += k;
+        }
+        s
+    }
+
     #[event]
     pub fn event(event: Event, vfp: &mut FetchFilters) {
         if let Event::Load = event {

--- a/varnish/tests/vmod_test/tests/test01.vtc
+++ b/varnish/tests/vmod_test/tests/test01.vtc
@@ -5,6 +5,7 @@ server s1 {
 	expect req.http.foo == "bar_replaced"
 	expect req.http.baz == "qux"
 	expect req.http.quxx == <undef>
+	expect req.http.all == "quxxHostUser-AgentX-Forwarded-ForVia"
 	txresp
 } -start
 
@@ -12,6 +13,7 @@ varnish v1 -vcl+backend {
 	import rustest from "${vmod}";
 
 	sub vcl_recv {
+		set req.http.all = rustest.merge_all_names();
 		rustest.set_hdr("foo", "bar_replaced");
 		rustest.set_hdr("baz", "qux");
 		rustest.unset_hdr("quxx");
@@ -22,4 +24,14 @@ client c1 {
 	txreq -hdr "quxx: quz"
 	rxresp
 	expect resp.status == 200
+
+
+	# make sure rustest.merge_all_names() doesn't panic on non-utf-8
+	send "GET / HTTP/1.1\r\n"
+        send "foo: "
+        sendhex "A7"
+        send "\r\n"
+        send "\r\n"
+
+        rxresp
 } -run


### PR DESCRIPTION
This is based on @gquintard 's work in #182 - but introduces a new `StrOrBytes` header value.

Note that the current code still appends `NUL` after the header if it does not contain it.