### PR TITLE
Bump version, remove unused publishing steps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 #
 #
 # ! STOP !  Update the version in dependencies below!!!
-version = "0.4.0"  ## <<<----- ! STOP !!!
+version = "0.4.1"  ## <<<----- ! STOP !!!
 # ! STOP !  Update the version in dependencies below!!!
 #
 #
@@ -24,9 +24,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions must match the one in the [workspace.package] section above
-varnish = { path = "./varnish", version = "0.4.0" }
-varnish-macros = { path = "./varnish-macros", version = "0.4.0" }
-varnish-sys = { path = "./varnish-sys", version = "0.4.0" }
+varnish = { path = "./varnish", version = "0.4.1" }
+varnish-macros = { path = "./varnish-macros", version = "0.4.1" }
+varnish-sys = { path = "./varnish-sys", version = "0.4.1" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.3.0"

--- a/justfile
+++ b/justfile
@@ -72,19 +72,9 @@ grcov:
 
 # Publish crates to crates.io in the right order
 publish:
-    #!/usr/bin/env bash
-    set -euo pipefail
     cargo publish -p varnish-sys
     cargo publish -p varnish-macros
     cargo publish -p varnish
-    LOCAL_VERSION="$(grep '^version =' Cargo.toml | sed -E 's/version = "([^"]*)".*/\1/')"
-    git tag -a "v$LOCAL_VERSION" -m "Release v$LOCAL_VERSION"
-    echo "A new tag v$LOCAL_VERSION has been created.  Please push it to the repository:"
-    if git remote get-url upstream > /dev/null 2> /dev/null ; then
-        echo "   git push upstream tag v$LOCAL_VERSION"
-    else
-        echo "   git push origin tag v$LOCAL_VERSION"
-    fi
 
 # Use the experimental workspace publishing with --dry-run. Requires nightly Rust.
 test-publish:


### PR DESCRIPTION
* Updated version in the package configuration.
* Updated version in workspace dependencies.
* Removed outdated publishing step instructions from comments.
