### PR TITLE
Refactor Varnish bindings generation

### DIFF
--- a/varnish-sys/bindings.for-docs
+++ b/varnish-sys/bindings.for-docs
@@ -9116,6 +9116,9 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn VSC_IsRaw(arg1: *const vsc) -> ::std::ffi::c_uint;
 }
+unsafe extern "C" {
+    pub fn VFP_Push(arg1: *mut vfp_ctx, arg2: *const vfp) -> *mut vfp_entry;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct http_conn {
@@ -9165,9 +9168,6 @@ impl Default for http_conn {
             s.assume_init()
         }
     }
-}
-unsafe extern "C" {
-    pub fn VFP_Push(arg1: *mut vfp_ctx, arg2: *const vfp) -> *mut vfp_entry;
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/varnish-sys/c_code/wrapper.h
+++ b/varnish-sys/c_code/wrapper.h
@@ -14,7 +14,9 @@
 #include "vapi/vsm.h"
 #include "vapi/vsc.h"
 
-#ifndef VARNISH_RS_6_0
+struct vfp_entry *VFP_Push(struct vfp_ctx *, const struct vfp *);
+
+#ifdef VARNISH_RS_HTTP_CONN
 struct http_conn {
         unsigned                magic;
 #define HTTP_CONN_MAGIC         0x3e19edd1
@@ -34,5 +36,3 @@ struct http_conn {
         vtim_dur                between_bytes_timeout;
 };
 #endif
-
-struct vfp_entry *VFP_Push(struct vfp_ctx *, const struct vfp *);


### PR DESCRIPTION
Consolidate all varnish logic in a `VarnishInfo` struct.  This is part of the new vsc code, but cleanly separated to simplify review.