### PR TITLE
Hack together a logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![crates.io version](https://img.shields.io/crates/l/varnish.svg)](https://github.com/gquintard/varnish-rs/blob/main/LICENSE)
 [![CI build](https://github.com/gquintard/varnish-rs/actions/workflows/tests.yaml/badge.svg)](https://github.com/gquintard/varnish-rs/actions)
 
+![Varnish Logo](./logo.svg)
+
 The `varnish` crate provides a safe and idiomatic interface to the [Varnish](https://varnish-cache.org/intro/index.html) C API, allowing you to write Varnish modules (VMODs) in Rust. See the [crate API](https://docs.rs/varnish) for more details.
 
 Some VMODs that use this library:

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,369 @@
+<svg width="100" height="100"
+     xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xml:space="preserve" version="1.1">
+    <g>
+        <g stroke-width="0" id="svg_80">
+            <g transform="matrix(1 0 0 1 540 540)"/>
+            <g transform="matrix(0.84 0 0 0.84 552.84 542.84)">
+                <circle fill-rule="nonzero" fill="rgb(255,255,255)" stroke-miterlimit="4"
+                        stroke-linejoin="miter" stroke-dashoffset="0" stroke-linecap="butt" stroke-dasharray="none"
+                        stroke-width="0" r="45" cy="-586.73465" cx="-597.78909" vector-effect="non-scaling-stroke"/>
+            </g>
+            <g transform="matrix(0.84 0 0 0.84 552.84 542.84)">
+                <circle stroke="rgb(154, 123, 147)" id="svg_2" fill-rule="nonzero" fill="rgb(195,163,188)" stroke-miterlimit="4"
+                        stroke-linejoin="miter" stroke-dashoffset="0" stroke-linecap="butt" stroke-dasharray="none"
+                        stroke-width="0" r="35" cy="-586.73465" cx="-597.78909" vector-effect="non-scaling-stroke"/>
+            </g>
+            <g id="svg_3" transform="matrix(0.92 0 0 0.92 552.94 543)">
+                <g id="cog">
+                    <g id="svg_5">
+                        <circle stroke="rgb(154, 123, 147)" id="svg_6" fill-rule="nonzero" fill="none" stroke-miterlimit="4"
+                                stroke-linejoin="miter" stroke-dashoffset="0" stroke-linecap="butt"
+                                stroke-dasharray="none"
+                                stroke-width="9" r="43" cy="-535.71429" cx="-545.80745"
+                                vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g transform="matrix(1 0 0 1 48.5 0)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_7" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-548.3074333667755,-532.7142947912216 -543.3074333667755,-535.7142947912216 -548.3074333667755,-538.7142947912216 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_8" transform="matrix(0.98 0.2 -0.2 0.98 47.57 9.46)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_9" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-644.2774198055267,-412.6722695827484 -639.2774198055267,-415.6722695827484 -644.2774198055267,-418.6722695827484 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_10" transform="matrix(0.92 0.38 -0.38 0.92 44.8 18.56)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_11" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-714.7671353816986,-285.1008460521698 -709.7671353816986,-288.1008460521698 -714.7671353816986,-291.1008460521698 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_12" transform="matrix(0.83 0.56 -0.56 0.83 40.33 26.94)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_13" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-753.6422915458679,-135.64409065246582 -748.6422915458679,-138.64409065246582 -753.6422915458679,-141.64409065246582 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_14" transform="matrix(0.71 0.71 -0.71 0.71 34.3 34.29)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_15" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-764.1350215673447,10.107854127883911 -759.1350215673447,7.107854127883911 -764.1350215673447,4.107854127883911 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_16" transform="matrix(0.56 0.83 -0.83 0.56 26.94 40.33)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_17" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-750.9239799976349,155.63859009742737 -745.9239799976349,152.63859009742737 -750.9239799976349,149.63859009742737 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_18" transform="matrix(0.38 0.92 -0.92 0.38 18.56 44.81)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_19" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-709.2662136852741,304.34377670288086 -704.2662136852741,301.34377670288086 -709.2662136852741,298.34377670288086 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_20" transform="matrix(0.2 0.98 -0.98 0.2 9.47 47.57)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_21" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-636.4079665541649,430.5774276256561 -631.4079665541649,427.5774276256561 -636.4079665541649,424.5774276256561 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_22" transform="matrix(0 1 -1 0 0 48.5)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_23" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-538.2142947912216,548.8074333667755 -533.2142947912216,545.8074333667755 -538.2142947912216,542.8074333667755 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_24" transform="matrix(-0.2 0.98 -0.98 -0.2 -9.46 47.57)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_25" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-418.1722695827484,644.7774198055267 -413.1722695827484,641.7774198055267 -418.1722695827484,638.7774198055267 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_26" transform="matrix(-0.38 0.92 -0.92 -0.38 -18.56 44.8)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_27" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-290.6008460521698,715.2670743465424 -285.6008460521698,712.2670743465424 -290.6008460521698,709.2670743465424 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_28" transform="matrix(-0.56 0.83 -0.83 -0.56 -26.94 40.33)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_29" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-141.14409065246582,754.1422915458679 -136.14409065246582,751.1422915458679 -141.14409065246582,748.1422915458679 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_30" transform="matrix(-0.71 0.71 -0.71 -0.71 -34.29 34.3)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_31" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="4.607854127883911,764.6350215673447 9.607854127883911,761.6350215673447 4.607854127883911,758.6350215673447 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_32" transform="matrix(-0.83 0.56 -0.56 -0.83 -40.33 26.94)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_33" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="150.13859009742737,751.4239799976349 155.13859009742737,748.4239799976349 150.13859009742737,745.4239799976349 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_34" transform="matrix(-0.92 0.38 -0.38 -0.92 -44.81 18.56)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_35" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="298.84377670288086,709.7662136852741 303.84377670288086,706.7662136852741 298.84377670288086,703.7662136852741 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_36" transform="matrix(-0.98 0.2 -0.2 -0.98 -47.57 9.47)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_37" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="425.0774276256561,636.9079665541649 430.0774276256561,633.9079665541649 425.0774276256561,630.9079665541649 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_38" transform="matrix(-1 0 0 -1 -48.5 0)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_39" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="543.3074333667755,538.7142947912216 548.3074333667755,535.7142947912216 543.3074333667755,532.7142947912216 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_40" transform="matrix(-0.98 -0.2 0.2 -0.98 -47.57 -9.46)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_41" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="639.2774198055267,418.6722695827484 644.2774198055267,415.6722695827484 639.2774198055267,412.6722695827484 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_42" transform="matrix(-0.92 -0.38 0.38 -0.92 -44.8 -18.56)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_43" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="709.7671353816986,291.1008460521698 714.7671353816986,288.1008460521698 709.7671353816986,285.1008460521698 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_44" transform="matrix(-0.83 -0.56 0.56 -0.83 -40.33 -26.94)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_45" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="748.6422915458679,141.64409065246582 753.6422915458679,138.64409065246582 748.6422915458679,135.64409065246582 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_46" transform="matrix(-0.71 -0.71 0.71 -0.71 -34.3 -34.29)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_47" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="759.1350215673447,-4.107854127883911 764.1350215673447,-7.107854127883911 759.1350215673447,-10.107854127883911 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_48" transform="matrix(-0.56 -0.83 0.83 -0.56 -26.94 -40.33)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_49" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="745.9239799976349,-149.63859009742737 750.9239799976349,-152.63859009742737 745.9239799976349,-155.63859009742737 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_50" transform="matrix(-0.38 -0.92 0.92 -0.38 -18.56 -44.81)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_51" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="704.2662136852741,-298.34377670288086 709.2662136852741,-301.34377670288086 704.2662136852741,-304.34377670288086 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_52" transform="matrix(-0.2 -0.98 0.98 -0.2 -9.47 -47.57)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_53" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="631.4079665541649,-424.5774276256561 636.4079665541649,-427.5774276256561 631.4079665541649,-430.5774276256561 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_54" transform="matrix(0 -1 1 0 0 -48.5)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_55" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="533.2142947912216,-542.8074333667755 538.2142947912216,-545.8074333667755 533.2142947912216,-548.8074333667755 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_56" transform="matrix(0.2 -0.98 0.98 0.2 9.46 -47.57)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_57" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="413.1722695827484,-638.7774198055267 418.1722695827484,-641.7774198055267 413.1722695827484,-644.7774198055267 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_58" transform="matrix(0.38 -0.92 0.92 0.38 18.56 -44.8)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_59" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="285.6008460521698,-709.2670743465424 290.6008460521698,-712.2670743465424 285.6008460521698,-715.2670743465424 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_60" transform="matrix(0.56 -0.83 0.83 0.56 26.94 -40.33)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_61" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="136.14409065246582,-748.1422915458679 141.14409065246582,-751.1422915458679 136.14409065246582,-754.1422915458679 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_62" transform="matrix(0.71 -0.71 0.71 0.71 34.29 -34.3)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_63" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-9.607854127883911,-758.6350215673447 -4.607854127883911,-761.6350215673447 -9.607854127883911,-764.6350215673447 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_64" transform="matrix(0.83 -0.56 0.56 0.83 40.33 -26.94)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_65" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-155.13859009742737,-745.4239799976349 -150.13859009742737,-748.4239799976349 -155.13859009742737,-751.4239799976349 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_66" transform="matrix(0.92 -0.38 0.38 0.92 44.81 -18.56)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_67" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-303.84377670288086,-703.7662136852741 -298.84377670288086,-706.7662136852741 -303.84377670288086,-709.7662136852741 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_68" transform="matrix(0.98 -0.2 0.2 0.98 47.57 -9.47)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_69" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="3"
+                                 points="-430.0774276256561,-630.9079665541649 -425.0774276256561,-633.9079665541649 -430.0774276256561,-636.9079665541649 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="mount" transform="matrix(1 0 0 1 0 -38.5)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_70" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="6"
+                                 points="-552.8074333667755,-539.2142947912216 -545.8074333667755,-532.2142947912216 -538.8074333667755,-539.2142947912216 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_71" transform="matrix(0.31 0.95 -0.95 0.31 36.62 -11.9)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_72" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="6"
+                                 points="-686.0795105695724,349.4397532939911 -679.0795105695724,356.4397532939911 -672.0795105695724,349.4397532939911 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_73" transform="matrix(-0.81 0.59 -0.59 -0.81 22.63 31.15)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_74" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="6"
+                                 points="118.50545907020569,749.2932006120682 125.50545907020569,756.2932006120682 132.5054590702057,749.2932006120682 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_75" transform="matrix(-0.81 -0.59 0.59 -0.81 -22.63 31.14)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_76" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="6"
+                                 points="748.0044326782227,107.93414568901062 755.0044326782227,114.93414568901062 762.0044326782227,107.93414568901062 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                    <g id="svg_77" transform="matrix(0.31 -0.95 0.95 0.31 -36.62 -11.9)">
+                        <polygon stroke="rgb(154, 123, 147)" id="svg_78" fill-rule="nonzero" fill="rgb(154, 123, 147)"
+                                 stroke-miterlimit="4"
+                                 stroke-linejoin="round" stroke-dashoffset="0" stroke-linecap="butt"
+                                 stroke-dasharray="none"
+                                 stroke-width="6"
+                                 points="333.2045681476593,-689.0482110977173 340.2045681476593,-682.0482110977173 347.2045681476593,-689.0482110977173 "
+                                 vector-effect="non-scaling-stroke"/>
+                    </g>
+                </g>
+            </g>
+            <g id="7990b146-a7ef-48a0-97b9-6f2d6698ea95" transform="matrix(1 0 0 1 540 540)">
+                <image id="svg_79" height="78" width="78" y="-531.85715" x="-541.14285"
+                       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAE4AAABOCAYAAACOqiAdAAAAAXNSR0IArs4c6QAAIABJREFUeF7tnAmYnXV59n/v/r7nPcucWTLJZDJJJsuE7AkBQWSR1lppFaxLbWv71dZ+VquULlr5XCoutepnFa3VWrUuVUSggCLiwibQkIQkZJ8kZJ9kZjL72d/9u57/YPWzrVLbAL0uz3VxJeHMnHPe+32W+7nv5380niWPY7Vs7p7dB181eGT48qlaq61QaqNSr2FZGpaeTC+eP3fXiv6+By5YXH7g2fCRtWfDh/iH2+75yM7H91/XDAHTJc106kGI53nEcYDvm6RhC8IWjqGzYc2az1+wYeNnNqzofuSZ+vzPOHC33L/9XXff+/BfhkGCZTkErYhCoQhk1BtVDCMjIyVJElxbng8xDEv9bFuhcPzqF15xw2Ubej//dAP4jAP3Fzd+eeepken1WqbhOQ6+5+G4Fn2988jnPIKwztjkGOPjk4yNT+K4PqlukWHTrFYoGAYDS3sfeOWvvegNizqdA08XgM84cH/8fz9/bGwmWESW0dfTw8uueTE5B7IELBOSNETXwXBtRkbH2bN3kM3bdtBoJhT9IlG1odJXI4x/5UVX3vjS56//86cDvGccuI987d7bH3ls7zWeY2FoOpdfegkrz1uOa2poWkLOs9H0jHqzgWE5WJZNnMCjWx5jy+atNGsReS9Pq9UiS0OWLV+843dfe82lPZrWOJcAPuPAbRkc2/SZr9y8LQwi0AUsg2XLlnDeyhUsXbqYoFXHdW0MLcWxTdIoxLYsoiAgTlPu+e6DbN68E8dtBwxM02TRgu4D//v1L75grqbVzxV4zzhwcmGfv/37f7V5y9brM90mjGMyw8Rxcyxa3MfKlSsoFPJ0dZQwSXAMjSxq4bsWksPNNGPf4DHu+uZDVKsRju3TbE7TO8cde921v7lqWaEwdi7Ae1YAJxf2uZu+8/G9Bw790fhMXTP9ApluEiSpiqDFixfS39dHV3uJOR1FygUXS89I05DM1NFMm+GzdT73ua8SRsJamhR9k+6yd+gP//R/bTgXafusAU7A+8Z9O37ngYc3//VktTWvEWfkCm2EcUKagO2YzO3soG/+PLq7yrSXi5RLPuX2PI1WC9N1GZ+o84Uv3Azo1KYrtOUcejrz+9923atX/XdH3X8auL1ZZo8dOnvVyaGh9adOnr68MjG1qF6t9tQbjUzIl0GWZlmGpmlYps78+T2DnuscX9y3YMuqFQP3rehre+wnXUSWZebn7vjOjdsf3/frtVbSYTt56kEMmYbluCoCbdelt2cuixb2UvZsFi2ch5MzSA2NXbv38Y2vf5u4ZeLoDraW8YIrnvu+l1+17u3/neA9ZeDu333sd7due/zq/UeO/0qCYdmuR6VSwdQNtCxRQDmWjWFopHFCksboGWRZgmPbRFGkCntnZ9fE8oGlt65eu/7vn7usvPM/upgsy7QHdh582Xfv/f4N07VwZaUekmGCaaNZJqZpo5OytLeXgaULKHbZzF8wF920uPuue9m/9xRxAHqMojev/f1XPGd9f2nrfxd4PxG4LMuMr31v6zse3bbjjSOjUx1+oYhuOjSaAUkGliVENMYwDBB2H0XEcahohWno6ELAQIGaxKn6M9N0NQU4jkNXZ3nHCy6/4K+uXLfktp90QcPVrGtw8Ngr9+w7/CeHjhxfUmk0wbTklfEcF93IWL12Cb19c+lfuoRC3uTGj36FqYkGSZSiJSHLFs879o43vbz/nAP39Yd3XvfNe+67Pky1OWGU4ro5dcGtRhPf9+iZO5d58+bSMaeDUluBfD6PKbchzRTvkmhL05SjR48q1n/85BATkxVSNDTDJM20WZYbt1g5sPjBl77kJa9ZMdc79h9dWGMy6xudmPmNx3bv/5PBw8e6pysz1KKY6UZIeU4ntfoUvQvmseH89axYMUC1HvC5z36RZjMg73i0qpO85IW/8A8XXbzxrQtK2uR/FcB/E3FZlukf+vw3vrv/8LErMsPUJfTr1Qr5nMvC3h4uWLeSlSuW4DummielnlmWjqlDKqVIUlTXVBRqmqJm6pEAEzMpWx7bybbHHmdscgrTcsl0Dy0DLarz/OddeMNvvPjid/3goqTeje4/8ysnnjj+jtHRifPiOM1l6OiWRZKmnG02OTQzw5lKDdfKqfk1DBtc9ZIXsWZ9Hw8/vI0tWzZTrzYoWj5tlsfGpUtGcllyeMN5i/65b9PST2qaFvwsIP5/wB2fzhZ/8COf+N5MI+y3cz7NltSViE3r13LZ8y5ibqePo4OppSRBE8exINVAS1WEGfJqWoqWSp8QmqUTp7oaymMgTjQcZxbER7fu4+vf/B61hkWcGTiuQRo1eN6mDfe95hWXvmzXo0/83sjhw9dlrXBB0grVxCDp2UwS9ae8xWiryd7xcabCFFPzyOJU3UzMmMtfcDFr163iE5/4OEQZemRgNEIuWbWGkplhtqoYZjK2cO2KL3cv6XlnV1dX9T8D4L8CNzjWGvibG//+O0Gi9SWariIpn7O55iUvon/+XAq+RZYIazfU3ZZi7yoUYhVVEjUKLGMWMHlIqgqg8m+pb6reIZGoqdePEo3bbnuAR7bvJvM9JutV2vI+Rc3gov6l5MMALwhwTZ16GlEjQSuVGW+0ODk8xkilSmJ71FoBed+n0WjgeQ5hHJCQ8lu//WoOHDjA3p278DIdMwxY1NbG0u4OikaGlsQkukEzDqeXnrfkc6suXfcWTea8p/BQV3OynvV8+KOf2taI0p5qIyKXy+FYBi9/2TX0dhbxPVPVojBqqHQQjBKJEsdRby7d7QfASJP4wUP+n4Aqndd4Elkte/J5AT/RyHkuj2w/wedu/2dS2yFJNPR6yLJimTW9vZSl/UQtYkcj9Gz2nRri9HSVRqRhuDnCNCPTNUwykiQiSmJFWQxbolJj7dr17N+9i7hWp6jDHNfhvL75uHGEK/GZaZiWRSNqUGjPn1q7ac2rOpbO/5efhp0C7oOf/tr9g0eOX9GMUiw3R7Gtnec99yI2rF+CIWFOpGZFQ0/RNZOIlDgRrqbjGAZZMgvcbF37YZoKNYnDUD2na7PcTnQMw9CxVBRCqxGjuyb3P7aXm+/4Bp7fDkGKVY1YvaifNtfF81zqacDeo0eoZTH1UAiRSyuKidFw/RxBvYZp6piWQa1ex7BtdPk8hklQb2JlqZKgcnHCJRvX4cUxZhLjZjq16gyOZyF1qBUH2cJliz+59vLzr/1J0adtOzx2xd9/+tP3Z6ZHlGk4fpFLL7uCcluRvp5OTAEibmEZmeJo0ll100C3HbJUw9Q0giBWqSvpF8cxraAx+3O6NA1DDeme6yr6YkhX1TIM9Vym6mWUJtiew/f+ZTe33n4XeadIXI3IWx7r1qwlThMOnThGNWhSjwIsxyGNMubM7WaiMq34ZMHPKcFT6JB0+GYUzyoqpqUEUGF9RhST1RtctHYNvqbhZSl2q0nZ96m36gRRgO07NJOAjrmdmy/+lcuv1DSt9e9Fn/bZOx74xy3bdvxumOhkusWmi55L55y5KrX8nENHKS+aP3nXUt2yGQbESUozjJieqdIKUhqNlpJ10jQmTGKazSZhGCogpcY5jq1kcNd1yXkexWKejnI75aJLuagTRxEYFpoJX/j8HRzYf4RSvoNmrUmxrYORiTGVemEmKrGlonbjmnUs7l/ImbOjnDh5nFarwcTYKM1mXb2XSO+5fFHxzVYzUDfK1Qz0MGbR3Ll05kssaCthVqdx01QSXd1oKc8xCZmZYhW9Y895zqbLcr0dQz8Onnb9R/5p56kzw+szzaZr3nw2XHCRumMSOTIkmlpMqzZDo16jIne3VlUR0GiFTM/UyFKDII7/NcI0XVd3PpVPrGXYpq0AlAiU/4Qqy4V1tLdTLnksWTKX/sULKJc7EIYThfDRj/w91UqLSDihaWN5OfV+cmGi2606bwUL58+na04HcZLg5z3SOCLNEqKgxa49u9m9Z99sSUk1ojjFc3wE8iQIcTSDtlye3lKR+a5Nm22iJSlpGGLqKYkmvxeRWRpee2HsssvPX6a1t8/8KHjaX9z41WNDZ4YX6aZLEGcsWrJcPT81NaXqUnVmmjQO0EhVqqrOaOgkmUYYxrM0IdNllFQ1bLZJSAOQzirdd3YcU6OZPP8kiLokrZGSagnl9oIYMJw3sIyeOT5btuznW9/6Nrbj0goSMt1QN6JQKHDB+Rvp6urAz7nkcmLsSBQainiblrxqhi0jXpowePgJvv/wo9TqDcJQbiboqVLtsDSdkmWxYt4c5ubz2GmMJmlum2SRNJkQJ59jrDbFgmWLd53/C895zo9yPu2jt37/H3c8tvN3hRtlGASRvLqB7/vUKjOqu2apXHym7rh0Lom4WcPEQjiWacg0oCv6IVH1QwBRDSONZ4mynv0QPEFaABH2mekZWhazsHcuF114AQMrFvA3f/NJ6o0Gtu0RRyltpRIrlg8wf/48SqUCmimURvQ3E0u6tsjrhoFtGLNNyjRIpIObBg8/spXNW7YjhpBhOBjoNBsBOcPACSMG+uazsKsTJ4kwoya2NLAsVdqgnvNoJBHdixZ8e+OV63/5XxnDkSwrfemTtz4wOHhofancTiuMCKVVOzlVpyTSTKXMampwFwCcnBu0lconir5/uKvoTOc9b0e5WEqLbW3HC75/3DKtJ1nd7GyhYWvTk2Prjx898UcHDx6+QMY2idYw1oicgvRsMgLSLCJf8rjokosYGRlh8MAh0jDC1C3WnreKhYskpUvoJhiONKoIRwZ+3cCWjvokgIo3GqDppuLnpmUyXQn5yk23MD42pcSCRiMgn/NBAiUK2LR8CV05Bydo0CEmUaWOa7mEaYrmODRJWLxi8euXP2f5p2b56JOPh/YM/fbg4L6NtXpzfb3Zim3LDRctWnRvHEdpoZBLO8ttDxeKpcTx/GPLOrTKT+M5P/68jHLfvO3e7VGcrperqVbqRJnBviPDpJZLNaxi+i5RFmHlXJavWMnWzY9i6ya2brBx1RrOW7kM05JITdBssGwTU0Y+Q8MyTBX5pqajG9osCddlajFU5KSSRXmTf77tfhV9xUKZmVqTRNPwpUtXp7hgYBkLij5ZtUa7uGkiZ2kWqTBVUye2EjZddP6a9qXte5+yrPSfBerHf/7wrsOvPbBn8B9k3pKGITWw3gjxcu0MTU4yND3O6ZkpZO5JDYtly1dw7MhxVcizKGT1wFLOP389hpliOhqpFuNYOpZElACmz/oNCjhN0lZTYoOQ9DCKVGmRsa7WhIOHT/HlL99MM04xi2VVYtLKNB2OxbrFi5jjefiajhVrZPEs+JL2rTRkTl/XiY0v3NT/tACXTWTFr99120g53+7JwC0eqp8rKOVCAEwchxOVGfadPsVUAprn06hHeLaDFsYQh6xdOcCGjauRXiRpqmdCIWJytjbLCQU0AU/TMWSSmA04VQNlFMsXCsQibYnnqMNj2w5y5z3f5WwjxHY8PC0jbTbw05SL16zDz3QKpoMRJYr+SKPLtJRmFrBu07oPPS3AHXh034cOH3ziz0WR1aQDCzipTBAacRJitBV5YM8+zrSa1DSLIJOBX6fo+WRyMa7FxvPXsmhJL5atI4TH9xx0LUE3EiwByhQRdRY4kbcEPEtLydJI0RUSGfEyLNtRZc214eFth7jl7u/QCGdFV1fEUWEBzYBfvuxStHoTT4O0WaeYc2m26gp4VT//qyn4035/cnKy9PgD26ezEMJmiKO7WIat7D1NOq6Vcmxigm0nThDmckR2gSBMKedLZEHEFRdfiKEldM/vRDMzdddFYfZNkaMiTDdDtzRMw1YRZ2mmGg0lhS0twXMtomZjVslRVMrENk1iGYgy2LL7GJ/54k0UimWq1SZ5r0jWCuhpK7Fm6UJy8h5RC09LyOIYy/ZUap9z4PY8tPXvxkfGX9+qBXimixZLGsnoZSCzTNWCB/bsYsawmEkzmonOvHnzWb9kgDnFAuWcSRQ30FyNRE8xLYecncPTHAxTJ9FbUr9VxClaogl42SxweoKRhPg5m7glMpijFGjhnRizkdNK4aFHB7n1zm9huSVqzQTfcaFVY0lPJ6sWdOATQrOGI8wi0HFs79wD9+Ad36nGzTBvxBp6quEaDs2GXKxL5Ngcrsyw5dAgkSgdhilCPKsHVrGibyEFy8BIWyo9cWQNwlTzsWO5aEFGzvcUcAKgaVgqVX+QorPACXeMVddMoqYiytJtFUGybJpBqrplosPNd3yfBx7Zhu21oWERNaoULLh0/QrctEW7bBY0W3i6Sypy/E9Ltf/K82PHxzY+tnnL9pzhYkQRWiiGsrB6jYquERbyPLjnAGONFqIBRhnMmTOH1avX0lUskimtL6WYz6nlG8u1VROQxlCQsTAQUDUsqTtKQ0zJeRZJ0iTvOirqkjhTJlKUhjiOSZoEKjItxPzO0FyDSpiSZDqf+swXGBqeJAp1PDdPWG9Szud47rpVlJKAvOh3lRrFnH9ugRvcuv/vjj9x/PUWJrZITyJ+iluvG0zbBqeDkG2HjlFLpdHNMv6BgQHmzZtHQcgpqRJORYYSSd61dTVOhWFTddKC76hGIHO1iAEyI5tWgqHFGFlMFstqmI8ujFmiT2Qxsb1S2XVyVXNqyDxsaTSTVPG6j33s01SqMmH4GLqt3mdhVwcruzsoy+cJAmyZpP4rEfXTfnffo3sePDs0fpmwf0e07iTFTg0i22DGcdh+9DiHzk6R2rPzrppFN21So5xjzgIpgPl+Tnm0rVaNnOvi+y6pOGWmQRZHFIttNMNETF2Rw/E8g7g1GxlGqs/+rCM+RYBjG0Rhgq27RFFGLLK/bZAYUA8jDh06zi233UUUiKdiYxoGVhKzadkiFrWV8KIWZnwOgcuyzBrac2LL5NmpDTMTU0p9kPlPLqSl60w7Fvft3M10opEYs7VrwYIFrF61atYAUhTDVDwskJQ0dXzfUR1RuRaZTNYZwydOU63WWbZ8NV3dRQxbAirBkMYgo1mqqVlbVBVJU9u2iKOMLLE5ePCIcu1WrT+PRhbgFnJKVPjqV25j6OQUtUaEZbtErTr9ne2sX7KIUhLhq7Wyc/RojVWWj4/MbI9bUX5k6Axho6lqi5DfBhpDcczDe/cSWx6tNMMyHVavXs2crq4n+djs0C6AieAi04HrmrQaIt/rdHR0MD0+wdvefD1apNGoRCq9F/f3cmbiNH/81jeyfOUSTMdUvM8RBVpSWZM6ZzB8tsp377mPuNHikssuZMnapQRppNCIwowPvP9vMd08rXD297wsYfXiBSxtb8MXJegc4cbMqckXTZ6duts2bM6eGaEyNT3L8LHUWCXu1N6hIWLDVss15bYONmzYoFJDaIM0AGX8iOmcsxV3k7VWyzAoFgvMzExx1ze+wZxSF/WJGtsf3oVniXEzTbEzzwf/7q/RchoJIhJkmFmsmoUW66SZxf0P7uT79z9CT6lMruhw9W9djV0wEbaSJhrHjoyoPZTYlJ08hzSo01PMcdnKlUpFOWfATZ2YuG5qbOojjulQmZ5h/OwYaST6nUtdM7hvcJAzjQYJs6ZKr6wyDAygy86JZSn3TBZtRLmXwV6GeNvWSWPZHNCVFlerVjFinW2P7ODYwdO4tvi0Cc/7hYsZWNeP7gu/E9syxVYNQ1JXzHCHj3/si0yNV+nM5ZmujnHtO65F9zKlBMmunmn43PfgVh7evlsN+ZkscWcRl69aRYfnnDvgxo6M3VCbmH6nENM4jBgZOaMkdsfOUzdM7tyyhWnxH3RLsf7FixfT09Oj9kzUI5Gm4Cu3X1JVUlZmT9c2lYQvup8Q1aQR8vXbvsnwqSkW9fUTRE3cosGv/toLKXV6ZEasZlpXpg5pTpo4cy5v+bP3smDeIqwEBo/u5z0fuwG7KNphUwkCrZo0Dpe//eyXlH8hTpuXhKybN4+BBQvOHXCn9516fxYmb00SMXkMTp8+pYAzLZ+xIOTu7Ttp2Y5UHbVesWLZctra2hRA0hw8W/iYLOzMAjUrVM7Ot4rwinohLluscfft97Bt8x7Wr9+AlqaYXso1L/1lOntKNJI6hkwfaUN5HlmkkTUMPvCXH+XkE2cUbzx48gk+d8un0XMJyZMWaBpatBKTo8Pj3HbnnaRJrIBb3zuf5b295w644f2nPhC34rcISxf1WCJO7DzTzHF8ssp39uwjEI82MxRgixYsUiKlpGSaxUoZER6n1GUlvesYpuhsswBKrRMPwcl09uzYy2c/+SVs0yEOW7zk6hfy0ldeRWbGWJ5JlMkNk0acoScaJa+d27/yHf7pS7fQ0dnJqbHTfO3bX6Qh6q+VMTE+SbHQRRCbTAcp/3znnUyMDlPQMlb1dLOir+8cAjd4+gOteust8mGFVtRqlScVDI/HDh1TwDVMR+ldkqLlcjudnR0KkNnVMJkGpObMbgIY4tuamlqzUN1WOrSeqSiqT1Z567VvY8nCJYyePc3LX3kNl1/1POVpCHnxbQOj2cJXVEanFcFYJeH6t7+btavWUIvqXPe2NzLVmMI0EnK5PNWZEDRXySg33XQbkyNn8JKIK9atoTN3DmfVM4fP/FVzun69pJvMiOJ3ujlfFeYHt+/h/gMHFXBaKquq/aohdHV14YrgJkO65KYUdeFM0hV1mTNFBZmNOgFOHHz5e971ufuWb3Hk4CGmq1O86c/eQEdvh5KV3BiObN1Jj26LT4id8zBLZUrLVnBsbJx9ew+y9vw1eO0OftljZmpy1oQy84gnV20E3HrLLSTVGXpKeZ6/dh2O1N1zRUdGj4zeMD029U7LnnX3k0S6oSgdJo/sPsD3Dx4lcHJksUF//1L1MTo6yviup2qYRJakrEwHQktk5066qfpTpewPdDchXhl5q8CxY8fIdxVp724jzALaTBtntM6uO77LGq/MvHyBphVzKm7hr1+Fv7iPehijeWIaBep35MalqfQmUxlXOx7fxa5t2yiQcdnGdcyxLAqO2Dnn6DF+cvwNY8NnPyFdUG0QaaladA1CnX3Hz/Ctx/dSE2lIc1jQu1Clc853Kfo5NY/KYqKkrJgwqq4pL+GHAM6mr9z5VBHfNJSc1rBLLtXGDG7Owm4ltE1nDG/eTXzoBL6pEzoJYUeBVde8iClLJzNNUj0j0iNaUUsNJWovxs6zf/8gjz76KEm9ykB3FxetPA+z0cCU+fYc4cb00PSVI2eG75WoEdVCeZ9CZxOb05UmX31wM2PNBNvymdvdo0xwcdNLeX/W9Ze7qlL2yZWJfwc4lcL27CVkiY7tOjQaFTo622jI5pOTw6kbROMzxBNTjI6epHPhHDr6F5B2lBirVMhZcuypiZXPKdtT1Ok00dm96wA7d+wibDVYPLeLDYsW0OXYFFIIa7VzB9zUmamFZ0+P7tENCnEcqYiSfQRLz9HSTb703Xs5U2nRDEzKXXPVCCVrFHnfo+jnKXiyKC0OqKYiTURHFXmqWczSE/l3qqfKQ5VRyrZcklSMGZSqkgaykeTiaTZDR48yMXmWjRevp6XFVJIIV6R5+Rknx3R9RqnD4uE+9OBDjJ0ZV65/3jR47oa1zC/kMIMWTpJhi7F+riJOXndw294tGdqF4ubL6pgM+lorRXddhoMaX73nXqZCl5bmUip30NnZSdhqkbNdOv0ivvOk/mZrah0BQ8hwii1+wpONQRQRtSkleyHSAGQBRQ6RaKEan8xMR/TAkeMjjI+eZeP5a4iIsHyPaquhpCPxjyenZtj++E5GxsdIGi3KojTHKb+4aRNFqbl6imcbxJKq2jkc8gW4Y3ueuLHRCK71PJ9mvYGJRs6wVfRUiRhrxdzzyOOcnqiLOE2uWKa/fwnVmRpGBJ6TU6695ZgYvo1hSaTJoJ5izlZwdEsIsmyJmmimpSYRqXWJHpAZKY4cNGmEnDk6yvx5vZTbcqRaSiArDo7HxMQUW7dt5+TwaWy1/hCTN3TaLZuLV60in0EpJ3wzoVKdoq1YUvzynEbc2ePDL5oYnfqmazqaGDU51yOIQqI0IhRRMOdTa8Y8cWqILXv2M9EIaKQa3fMX4bpFfL+kttVN28L2XHKOoxTenGOinNk0IiclQJs1cTK11a6OdKFbKZpIS4ahdvoqM4HiZ3LRos1NTc1w7MhR9u3YjZv3qdAkbbboNiyWdHSyur9flQ1ZwJG1Ns8V6pQoxXl6WobFc/jIssw+vG1wN1E2YCY6lutQT0J0ZSTLrkmsLljUkelak32HjnL45AgzjRArXyYyHLxiG6brYbqi5EonnR3HSk6OnGPje66KOKmDApg0FE0pvQKcyD86qS7lVZPTGWqXbnR0lOHhYVX3SnJuTJXfAK1RZT42L7niCrUw6bQVicp5WiJrZRo5xyVoNZTAcE6Bk3vyxGMH/8GItdeaImDGEZkvvmaIFYg0k2DLsfE4Uq65lVrUpmp876FHOHR6GG/uPCY1jZZrkzp5NMfDMT1yTk5J8BJJsaSpAOjYuI6l6p+e/evqCvV6g1S2ruoVdMdgePQMM9UqjWaNNtegGNcwJsYwx8aYPnwERzY704yXvPLlrHn+5dS62tFKbeiZjXhzYaOFa0rROceP8SfGr5waOfsNz7JzkqJ14V5JTKfpostecdIibTU4tGM3h7bvYs9juwiimMDQcLq6Mbs7Mdo7sTq6legZpLJKq2NYvmoygeq4Bq5uKr9WmoZleUpMEB1N/Ag5WhA0phgfHVInDzUiEHIdVwlOHqJycB/56Rq++K9Zgue71NIMb0EvL33jm+hceh5prsjUdJ2uUhk9O8fN4Qf35PCje28lSl4mblSQNvElPZohteER7r37LgYf30kwPYMeSc2yCMMWubxPvdHC8nxqcUpk5nC65pFf3I/ZM5cZy2QiDnBU4RbHRvwJ2er0sArteMUe3FwbWpyiB3VKcZXpYwfxggpTJw8RVs8Sjp0hL6tkjSq+MrETTNdgqlohE8dfc0gylxe86tVs/PVXkJSKarYbXlNXAAAItklEQVROhB2c44BTLz/+xNCVE6MjN9sanbKzXhse5v7b7mT/lq0QNHGF3Mr+rayTxaGKGuFjs8RWuJtNqjnUdIuq5xC3t6HNm4MpK1/6rDVoZBaa2JBuHqfYiVuci5Mrq00nvdUgOnuKiUN7GN23k0Jcw4lr5OKIbsMhJ8ek4ib1VpVKUKfQ1c50GJAqEzHHRJKx6uoX8+I/+APSXJ56En/taQFOcbrNW6+1g9aN+x/4Po98/S6qp07T5rvqJIyepjipbNGJize7jyvyo9ptE7/0yV0TdIvENGmZOg0d5c8ayA7J7MAfJZFqQGEUY+gOnXO6lfs1PTOpDrTkDMinMVarRiGJKJsu3cVuzBS6ymXVbYfGzjBcGWeGiFokr+cxXQ8wyh2suPQyfukPf++OOasGfu9pA27q6NF1H3/3DY8ff+ARSo2AeV6O6tQETt5VZ5ksOR2Tor6YQEnnMkfKvKoWhTJBSdl8Yu3JylWiXHtR5GyCIFANR7pds9kgV8irQyJyCFhWuZCtI9OmOTNDu2Mwv5CnTTZMQ7lFHrblqQMksmabKxVwSjkmWhWOnx1maOIsViFPI4ZhLeMNn/roO9a+9GXvfdqAk6i77qoXnjAOnewrVurY9SZF1yaWtXnHpc2wsGW9QfQ7kYxkrVdS17LUDOp4vhrbRPKRta0gjNXySyipbolzJamtE6UGmmOhFQwioT1+kVYAebuNnFSmqWFao0N0Ogb1ZouK5eH6RaxmStYKFaeTQ35yUscr5zkyPsxjxw4zY8BEMcdf3vxP67rPv2j30wpcsPuxFe/+7dc9kp+Yae/IUEePHN3GNkx1UEMXginpKYc7ZAPSAKdQYLpWod4MlBDqC59LNbXK32jUcHybzNEJTQ2n3MH8/tX0LF6MWzYxSx7Ogn7IHEaOThJXqjRP7GVq/04KMxXqM9OcataJZCUihJwcGZAlwiBUAoFsFGjFPENJg68f2MnVf3btey/50z99hwTB0wqcvOHwrbe+8jNvf8/NPei0hxrtiYkRye5GTGJmaI5BYhs0koBK2OLM5Dhq6Vc2kVIdXaJHc5hX6qTc3kktCzAXzmHdb/4qHS94AeS6Zhfe46Y6KYPhMHS2zubBYZYvXsS6+SaMT3L47e9naOtWxqtjBFmkFm+EYNuaUBsbHxs7s1jS18+YazG2sudffunD77vkB830aQdO3njLDe9776Nfvf1tPalGWyXCk212OQ5kZFSSgKmgMXuKRqYMoQVq633WY3ATnVyiUTZ9fC9PbDtc88F3wZXroVhkIjW54+7NvOpXLyaOM0Jb4zV/8UFORgW12fmZ61/LhTmX4+//GIN3fYsnhgaJjISmI80oxUt1SrZHh13C0T06uxdQWr/y8MB1b7pAW/LDsw7PCHAC3o7/855P7brzG6+bI+ZuFFLNEqbjgIlmS3Uz07LVV2jIUacEOQcmKw8JRhipkzDdfoGuUgfEFuV1q7jw0x+EfDs3f28PX7z5dt71ltexYkU3p+rw+nfcyJm4DdfQePM1m/idC1Zy4M/ezZHv3c/+sydpulB1RDCAUgpWI6KEh9/ZTd/zLz122Xuv36iVy9M/St2eMeDkQzz65rd/as/3vvm6aGqCmXqDQNMJnDyB6RJbOTUZiOSTRHJuNsZMY5woIh8HdJsa3TKv4tH0c1zyx69l7qteTWRZ7DoeMrDMpiGiow5vfv+XeWK4qTrqp976GvqTkIf/4DpO7xlksr0Ive1MphWmpsbRahWSqQrdXhv969aeesWH37NB6+2d+HG++4wCJx9m5ydufMtn//p9787HieO4Jc6ENmn3QnqecykNW/Z6M2LhZ9Ixp6dIx8YJjwzSH9Xp1TW8UMMp5KkXXX7tb2+EZSuIXZ3AgiYgX3Uj4v2RwQnW9nXQZsD0t+9l60c/z9hEjZkN6zibd8nMWU+1OT3Bod2Pc8mF5w+99Yb3r9MWlP7dY+jPOHAC3qm7b3/RB6/945sM3SvNWJ10rLuIxvx+puWgh+hvol6EiTJfrJka+bOnyR/dT3lilHniucqp6ZxHrVTk5R/7KKxaSdODN773Y8w0mlz/p29iXVcOU76grhnyyP/5S0Yf2IHVs5ADywY4mXPVdlOrPoPvGFx26XPe89JXXPXOnzRVPSuAU6PV0OHev37zO7++4+jZDYsuvBx38QqOz8wQJ00lfCaprmTuLt2jq1Wn4+xxop1bWZEl5FoNQtnvyLcRd8zjqr96H2eX9/Hqd71TfRfJ+952PevmlHDrAdz6TR765D8SD49jLR9gc98C3AvWsXrleQws7Vvhuma9oyP3b04LPutS9cc/0MPfevD379225+OTmeW94OqrmZwZwy34xJrB0YPHOLR9L35thiVJi3D7v7B0apSOsIVpuNRFRnbbafT1cfUnPsRhM+XIxFl+8bnrcaMUdu3nvr94D9nRk0oaivsXMvkLl7P6FS/7pWWL2+/XNE2+OuApPZ41Effjn/buh/a8rbO7py+Im79c6u7sy6zZ8wlf/sxNWJUq/uQowc4trJ4co7tWxzUtJQYEmUXdztHs6OQFb/h9CldfCVEDTozy7Xe9B06MkDbq5Lo6OJ23WP6617z9gl+76n1PCa0f+aFnLXA/+Iwj083FzSQZqKWsMSx/4KYvfO33Z4bO4DWmSQ/sZdnIMH1hiBGn1Cp15vb2MjJRwSy0EXSW6H7+JpatPo8Hv3wr4fgkE8PDLFq+dOLFv/ObH9Iv3/SZf69jPhUQn/XA/ehFjGSZ/+g9Wz+8Y+vWX81qU/Nndu1M+kYmjH7NJJPvk4tDNMvGLvqKD4oYqvsudqlIx/y5Z1dffNFN/edv/Ky29rw9TwWc/xHN4We5kKHtu66c34rMIw888rKC53pkmhklkW7l3dBqLxwsd/Y8wdyuo6xavuOpfi3GU/0c/6Mi7qle1NPxcz8H7mdE+efA/Ry4nxGBn/HXfh5xPwfuZ0TgZ/y1/wctPzUhsDjG6AAAAABJRU5ErkJggg=="
+                       vector-effect="non-scaling-stroke"/>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
The logo is based on varnish-cache + the commonly-used rust gear... plus a few SVG hacks and fixes.

We may want to spend a bit more time with it and make it more like https://github.com/maplibre/maplibre-rs#readme

See also https://github.com/rust-lang/rust-artwork/blob/master/logo/rust-logo-gear-only.svg