### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.2](https://github.com/varnish-rs/varnish-rs/compare/v0.5.1...v0.5.2) - 2025-06-13
+
+### Other
+
+- automate publishing with Release-plz ([#212](https://github.com/varnish-rs/varnish-rs/pull/212))
 # Unpublished
 - Removed `package.metadata.libvarnishapi.version` from `varnish-sys` metadata. Use `DEP_VARNISHAPI_VERSION_NUMBER` env var available in your `build.rs` instead. In some cases you may want to save this version into some build output dir for subsequent use by the packaging scripts.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.5.1"
+version = "0.5.2"
 repository = "https://github.com/gquintard/varnish-rs"
 edition = "2021"
 rust-version = "1.82.0"


### PR DESCRIPTION



## 🤖 New release

* `varnish-sys`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `varnish-macros`: 0.5.1 -> 0.5.2
* `varnish`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `varnish-sys`

<blockquote>

## [0.5.2](https://github.com/varnish-rs/varnish-rs/compare/v0.5.1...v0.5.2) - 2025-06-13

### Other

- automate publishing with Release-plz ([#212](https://github.com/varnish-rs/varnish-rs/pull/212))
</blockquote>

## `varnish-macros`

<blockquote>

## [0.5.2](https://github.com/varnish-rs/varnish-rs/compare/v0.5.1...v0.5.2) - 2025-06-13

### Other

- automate publishing with Release-plz ([#212](https://github.com/varnish-rs/varnish-rs/pull/212))
</blockquote>

## `varnish`

<blockquote>

## [0.5.2](https://github.com/varnish-rs/varnish-rs/compare/v0.5.1...v0.5.2) - 2025-06-13

### Other

- automate publishing with Release-plz ([#212](https://github.com/varnish-rs/varnish-rs/pull/212))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).