### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/varnish-rs/varnish-rs/compare/v0.5.2...v0.5.3) - 2025-07-03
+
+### Other
+
+- fix URLs to point to correct github org ([#216](https://github.com/varnish-rs/varnish-rs/pull/216))
+
 ## [0.5.2](https://github.com/varnish-rs/varnish-rs/compare/v0.5.1...v0.5.2) - 2025-06-15
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.5.2"
+version = "0.5.3"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.82.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.5.2" }
-varnish-macros = { path = "./varnish-macros", version = "0.5.2" }
-varnish-sys = { path = "./varnish-sys", version = "0.5.2" }
+varnish = { path = "./varnish", version = "0.5.3" }
+varnish-macros = { path = "./varnish-macros", version = "0.5.3" }
+varnish-sys = { path = "./varnish-sys", version = "0.5.3" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.5.0"


### PR DESCRIPTION



## 🤖 New release

* `varnish-sys`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `varnish-macros`: 0.5.2 -> 0.5.3
* `varnish`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `varnish-sys`

<blockquote>

## [0.5.3](https://github.com/varnish-rs/varnish-rs/compare/v0.5.2...v0.5.3) - 2025-07-03

### Other

- fix URLs to point to correct github org ([#216](https://github.com/varnish-rs/varnish-rs/pull/216))
</blockquote>

## `varnish-macros`

<blockquote>

## [0.5.3](https://github.com/varnish-rs/varnish-rs/compare/v0.5.2...v0.5.3) - 2025-07-03

### Other

- fix URLs to point to correct github org ([#216](https://github.com/varnish-rs/varnish-rs/pull/216))
</blockquote>

## `varnish`

<blockquote>

## [0.5.3](https://github.com/varnish-rs/varnish-rs/compare/v0.5.2...v0.5.3) - 2025-07-03

### Other

- fix URLs to point to correct github org ([#216](https://github.com/varnish-rs/varnish-rs/pull/216))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).