### PR TITLE
Remove varnishsys_77_vmod_data cfg

### DIFF
--- a/varnish-macros/AGENTS.md
+++ b/varnish-macros/AGENTS.md
@@ -8,7 +8,7 @@ See also: [workspace root](../AGENTS.md) · [varnish-sys](../varnish-sys/AGENTS.
 - `#[derive(VscMetric)]` (attrs `counter`, `gauge`, `bitmap`) — derives VSC metric structs.
 - `run_vtc_tests!("glob")` — generates one `#[test]` per matching `.vtc` file.
 
-`build.rs` reads `DEP_VARNISHAPI_VERSION_NUMBER` (from `varnish-sys`'s `links = "varnishapi"`), sets `cfg(varnishsys_77_vmod_data)` + `VARNISHAPI_VERSION_NUMBER` env — couples codegen to installed Varnish version.
+`build.rs` reads `DEP_VARNISHAPI_VERSION_NUMBER` (from `varnish-sys`'s `links = "varnishapi"`), sets the `VARNISHAPI_VERSION_NUMBER` env var — couples codegen to installed Varnish version.
 
 ## Pipeline model
 

--- a/varnish-macros/build.rs
+++ b/varnish-macros/build.rs
@@ -1,13 +1,10 @@
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(varnishsys_77_vmod_data)");
     // Only 8.0+ and trunk supported
     let ver = std::env::var("DEP_VARNISHAPI_VERSION_NUMBER")
         .expect("DEP_VARNISHAPI_VERSION_NUMBER not set");
     if ver == "trunk" {
         // Treat trunk as latest Varnish
         // Add any config options for latest Varnish here
-        // If you add new cfgs for 8.x, add them here too
-        println!("cargo::rustc-cfg=varnishsys_77_vmod_data");
         println!("cargo::rustc-env=VARNISHAPI_VERSION_NUMBER=trunk");
         return;
     }
@@ -17,8 +14,4 @@ fn main() {
         "cargo::rustc-env=VARNISHAPI_VERSION_NUMBER={}.{}.{}",
         ver.major, ver.minor, ver.patch
     );
-
-    if ver >= semver::Version::new(7, 7, 0) {
-        println!("cargo::rustc-cfg=varnishsys_77_vmod_data");
-    }
 }

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -226,13 +226,9 @@ impl Generator {
         let c_func_name = self.names.func_struct_name().force_cstr();
         let func_name = quote! { func_name: #c_func_name.as_ptr(), };
 
-        let vmod_data_extras = if cfg!(varnishsys_77_vmod_data) {
-            quote! {
-                vcs: c"".as_ptr(),  // FIXME: value?
-                version: c"".as_ptr(),  // FIXME: value?
-            }
-        } else {
-            quote! {}
+        let vmod_data_extras = quote! {
+            vcs: c"".as_ptr(),  // FIXME: value?
+            version: c"".as_ptr(),  // FIXME: value?
         };
 
         quote!(


### PR DESCRIPTION
## Summary
- `varnish-macros/build.rs` set a `varnishsys_77_vmod_data` cfg whenever the detected Varnish version was `>= 7.7.0` (or `trunk`), gating whether the generated `vmod_data` struct literal included the `vcs`/`version` fields.
- The workspace only supports Varnish 8.0+/trunk now, so this cfg was always true in practice — the `else` branch in `generator.rs` was dead code.
- Removed the cfg declaration/setting from `build.rs` and the conditional in `generator.rs`; `vcs`/`version` are now always emitted unconditionally. Updated the stale mention in `varnish-macros/AGENTS.md`.

## Test plan
- [x] `cargo check -p varnish-macros -p varnish --all-targets`
- [x] `cargo test -p varnish-macros` — no snapshot changes, confirming generated code output is unchanged
- [x] `grep -rn "varnishsys_77_vmod_data"` returns nothing