### PR TITLE
Skip vmod_synthbuffer's vtc test on Varnish trunk

### DIFF
--- a/examples/vmod_synthbuffer/tests/test01.vtc
+++ b/examples/vmod_synthbuffer/tests/test01.vtc
@@ -1,5 +1,11 @@
 varnishtest "synthbuffer.push()/push_reverse() from vcl_synth and vcl_backend_error"
 
+# Varnish trunk's default synth-response storage (ssy) doesn't copy the synth
+# VSB into the object unless VCL opts out via the (trunk-only) resp.storage
+# variable, so vcl_synth's body comes back empty there. Skip until that
+# upstream feature stabilizes rather than forking this VCL per Varnish version.
+feature !cmd {pkg-config --modversion varnishapi | grep -qx trunk}
+
 server s1 {
     rxreq
     txresp


### PR DESCRIPTION
## Summary
Follow-up to #322. That PR fixed the `ssl_ca_file` compile error against Varnish trunk, but the trunk job then failed on a separate, unrelated issue: `vmod_synthbuffer`'s vtc test (`EXPECT resp.body () == "hello dlrow" failed`).

Root cause (confirmed against a real trunk checkout): trunk added a new default storage engine for synth-response bodies (the `ssy` stevedore) that's zero-copy by design. The code that used to unconditionally copy the `vcl_synth` VSB into the response object is now conditional on the stevedore *not* being `ssy` — and since `ssy` is the new default, nothing copies our vmod's `push()`/`push_reverse()` output into the object, so the body comes back empty. This isn't a bug in `Ctx::response_buffer()` — it writes to exactly the `struct vsb *` the `vrt.h` contract documents, unchanged from stable.

Trunk added a new VCL variable, `resp.storage`, settable only in `vcl_synth`, to opt out of `ssy` (e.g. `set resp.storage = storage.transient;`). But that variable doesn't exist on any released Varnish, so the same VCL can't use it without breaking 8.0/9.0/latest — and this project has no mechanism to give different VCL to different Varnish versions within one `.vtc` file.

Rather than build that machinery for a feature upstream hasn't finished (their own code has an `// XXX ... we do not use synth_body` comment acknowledging it), skip the test on trunk using varnishtest's own `feature !cmd` directive, keyed off `pkg-config --modversion varnishapi` reporting the literal string `"trunk"` — the same signal this crate's own `build.rs` already uses for its `varnishsys_*` version cfgs.

## Test plan
- [x] `just ci-test` (stable Varnish 9.0.3) — test still runs and passes normally, not skipped
- [x] Confirmed empirically against a real trunk checkout that the test is skipped there instead of failing